### PR TITLE
highlight code snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It provides:
 
 ## Example code
 
-```
+```python
 import pandas
 from formulaic import Formula
 
@@ -112,7 +112,7 @@ y, X = Formula('y ~ x + z').get_model_matrix(df)
 
 Note that the above can be short-handed to:
 
-```
+```python
 from formulaic import model_matrix
 model_matrix('y ~ x + z', df)
 ```


### PR DESCRIPTION
Hi!

Looking through this project, I was a bit sad to see that the code snippets in the README weren't highlighted.

I think it makes things easier to read and a bit prettier.
Before:

<img width="943" height="333" alt="image" src="https://github.com/user-attachments/assets/3f6605cb-4b94-4f21-bd44-6f12914146c1" />

After:


<img width="1139" height="330" alt="Screenshot 2025-07-15 at 22 31 39" src="https://github.com/user-attachments/assets/2a11b175-9215-4d67-a01a-391542b13701" />
